### PR TITLE
Allow alternate ruby installations

### DIFF
--- a/redis-audit.rb
+++ b/redis-audit.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 #    Copyright (c) 2012, Simon Maynard
 #    http://snmaynard.com


### PR DESCRIPTION
This enables ruby installed from ruby version managers (such as rvm, rbenv, chruby), rather than the system ruby to also work with the script