### PR TITLE
Add support for :password argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ The script provides two different methods of being run, one with argument decler
 
 The legacy option looks like this:
 
-    redis-audit.rb [host] [port] [dbnum] [(optional)sample_size]
+    redis-audit.rb [host] [port] [password] [dbnum] [(optional)sample_size]
 
 You can also specify the arguements with declerations, which also adds the ability to use a Redis URL and pass in authentication credientials:
 
-    redis-audit.rb -h/--host [host] -p/--port[port] -d/--dbnum [dbnum] -s/--sample [(optional)sample_size]
+    redis-audit.rb -h/--host [host] -p/--port [port] -a/--password [password] -d/--dbnum [dbnum] -s/--sample [(optional)sample_size]
     
     or
     

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ You can also specify the arguments with declarations, which also adds the abilit
   
 - **Host**: Generally this is 127.0.0.1 (Please note, running it remotely will cause the script to take significantly longer)
 - **Port**: The port to connect to (e.g. 6379)
-- **DBNum**: The Redis to connect to (e.g. 0)
+- **Password**: The Redis password if authentication is required
+- **DBNum**: The Redis database to connect to (e.g. 0)
 - **Sample size**: This optional parameter controls how many keys to sample. I recommend starting with 10, then going to 100 initially. This
 will enable you to see that keys are being grouped properly. If you omit this parameter the script samples 10% of your keys. If the sample size is
 greater than the number of keys in the database the script will walk all the keys in the Redis database. **DO NOT** run this with a lot of keys on 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The legacy option looks like this:
 
     redis-audit.rb [host] [port] [password] [dbnum] [(optional)sample_size]
 
-You can also specify the arguements with declerations, which also adds the ability to use a Redis URL and pass in authentication credientials:
+You can also specify the arguments with declarations, which also adds the ability to use a Redis URL and pass in authentication credentials:
 
     redis-audit.rb -h/--host [host] -p/--port [port] -a/--password [password] -d/--dbnum [dbnum] -s/--sample [(optional)sample_size]
     

--- a/redis-audit.rb
+++ b/redis-audit.rb
@@ -335,7 +335,12 @@ else
   if options[:dbnum].nil?
     options[:dbnum] = 0
   end
-  redis = Redis.new(:host => options[:host], :port => options[:port], :password => options[:password], :db => options[:dbnum])
+  # don't pass the password argument unless it is set
+  if options[:password].nil?
+    redis = Redis.new(:host => options[:host], :port => options[:port], :db => options[:dbnum])
+  else
+    redis = Redis.new(:host => options[:host], :port => options[:port], :password => options[:password], :db => options[:dbnum])
+  end
 end
 
 # set sample_size to a default if not passed in

--- a/redis-audit.rb
+++ b/redis-audit.rb
@@ -289,6 +289,10 @@ OptionParser.new do |opts|
     options[:port] = port
   end
 
+  opts.on("-a", "--password PASSWORD", "Redis Password") do |password|
+    options[:password] = password
+  end
+
   opts.on("-d", "--dbnum DBNUM", "Redis DB Number") do |dbnum|
     options[:dbnum] = dbnum
   end
@@ -305,14 +309,15 @@ end.parse!
 
 # allows non-paramaterized/backwards compatible command line
 if options[:host].nil? && options[:url].nil?
-  if ARGV.length < 3 || ARGV.length > 4
+  if ARGV.length < 4 || ARGV.length > 5
     puts "Run redis-audit.rb --help for information on how to use this tool."
     exit 1
   else
     options[:host] = ARGV[0]
     options[:port] = ARGV[1].to_i
-    options[:dbnum] = ARGV[2].to_i
-    options[:sample_size] = ARGV[3].to_i
+    options[:password] = ARGV[2].to_i
+    options[:dbnum] = ARGV[3].to_i
+    options[:sample_size] = ARGV[4].to_i
   end
 end
 
@@ -330,7 +335,7 @@ else
   if options[:dbnum].nil?
     options[:dbnum] = 0
   end
-  redis = Redis.new(:host => options[:host], :port => options[:port], :db => options[:dbnum])
+  redis = Redis.new(:host => options[:host], :port => options[:port], :password => options[:password], :db => options[:dbnum])
 end
 
 # set sample_size to a default if not passed in


### PR DESCRIPTION
Currently, it is not possible to use the password argument with this project when connecting to a Redis instance. This pull request adds in support and documentation of the password argument.

Addresses #46 