### PR TITLE
fix: docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY . /redis-audit
 RUN set -ex; \
     apk --no-cache add build-base; \
     cd redis-audit; \
+    bundle update --bundler; \
     bundle install; \
     apk del build-base;
 


### PR DESCRIPTION
Build was failing with this error:
```
Installing hiredis 0.6.0 with native extensions

NoMethodError: undefined method `dir_mode=' for "/usr/local/bundle/cache/hiredis-0.6.0.gem":String

    @package.dir_mode = options[:dir_mode]
            ^^^^^^^^^^^
```