### PR TITLE
Cluster mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .bundle/
 vendor/
+# Remove if using rbenv
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'redis'
 gem 'hiredis'
+gem 'redis-clustering'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'redis'
 gem 'hiredis'
+gem 'redis'
 gem 'redis-clustering'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    hiredis (0.6.0)
-    redis (3.2.2)
+    connection_pool (2.4.1)
+    hiredis (0.6.3)
+    redis (5.1.0)
+      redis-client (>= 0.17.0)
+    redis-client (0.21.0)
+      connection_pool
 
 PLATFORMS
   ruby
@@ -12,4 +16,4 @@ DEPENDENCIES
   redis
 
 BUNDLED WITH
-   1.11.2
+   2.4.19

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The legacy option looks like this:
 
 You can also specify the arguments with declarations, which also adds the ability to use a Redis URL and pass in authentication credentials:
 
-    redis-audit.rb -h/--host [host] -p/--port [port] -a/--password [password] -d/--dbnum [dbnum] -s/--sample [(optional)sample_size] -c/--cluster (optional)
+    redis-audit.rb -h/--host [host] -p/--port [port] -a/--password [password] -d/--dbnum [dbnum] -s/--sample [(optional)sample_size] -c/--cluster (optional) -m/--memory (optional)
     
     or
     

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This script samples a number of the Redis keys in a database and then groups them with other *similar* looking keys. It then displays key 
 metrics around those groups of keys to help you spot where efficiencies can be made in the memory usage of your Redis database.  
-_Warning_: The script cannot be used with AWS Elasticache Redis instances, as the debug command is restricted.
+_Warning_: The script cannot provide idle time on AWS Elasticache Redis instances, as the debug command is restricted.  Use the memory flag instead.
 
 ## Installation
    `bundle install` will take care of everything!
@@ -40,6 +40,7 @@ greater than the number of keys in the database the script will walk all the key
 a production master database. Keys * will block for a long time and cause timeouts!
 - **Url**: Follows the normal syntax for Redis Urls
 - **Cluster Mode**: Connect to a cluster endpoint
+- **Memory Flag**: Use the memory command for key sizing.  Idle time will not be available if this flag is used.
 
 `redis-audit.rb --help` will print out the argument options as well.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The legacy option looks like this:
 
 You can also specify the arguments with declarations, which also adds the ability to use a Redis URL and pass in authentication credentials:
 
-    redis-audit.rb -h/--host [host] -p/--port [port] -a/--password [password] -d/--dbnum [dbnum] -s/--sample [(optional)sample_size]
+    redis-audit.rb -h/--host [host] -p/--port [port] -a/--password [password] -d/--dbnum [dbnum] -s/--sample [(optional)sample_size] -c/--cluster (optional)
     
     or
     
@@ -39,6 +39,7 @@ will enable you to see that keys are being grouped properly. If you omit this pa
 greater than the number of keys in the database the script will walk all the keys in the Redis database. **DO NOT** run this with a lot of keys on 
 a production master database. Keys * will block for a long time and cause timeouts!
 - **Url**: Follows the normal syntax for Redis Urls
+- **Cluster Mode**: Connect to a cluster endpoint
 
 `redis-audit.rb --help` will print out the argument options as well.
 

--- a/redis-audit.rb
+++ b/redis-audit.rb
@@ -22,7 +22,7 @@
 
 require 'bundler/setup'
 require 'redis'
-require 'redis/connection/hiredis'
+require 'hiredis'
 require 'optparse'
 
 # Container class for stats around a key group


### PR DESCRIPTION
Two enhancements in this PR:

- Cluster Mode:  Uses `redis-clustering` Gem to connect to cluster and auto discover nodes.
- Memory Flag:  Use the [memory usage](https://redis.io/commands/memory-usage/) command (Redis 4.0 and up) to get key sizes.  Allows the use of the script against AWS Elasticache instances.

There's a TODO in the code for smarter defaulting of the memory flag, but at present what's in the PR meets my requirements.